### PR TITLE
Object parameters implicitly has any type

### DIFF
--- a/src/02-object-param.problem.ts
+++ b/src/02-object-param.problem.ts
@@ -1,13 +1,15 @@
 import { expect, it } from "vitest";
 
+// Create an Interface
 interface addNumberProps {
   first: number;
   second: number;
 }
 
-// These commented solutions can also work
+// Named Type
 // type NewType = { first: number; second: number };
 
+// Pass an Object Type Directly
 // export const addTwoNumbers = (params: { first: number; second: number }) => {
 //   return params.first + params.second;
 // };

--- a/src/02-object-param.problem.ts
+++ b/src/02-object-param.problem.ts
@@ -1,6 +1,18 @@
 import { expect, it } from "vitest";
 
-export const addTwoNumbers = (params) => {
+interface addNumberProps {
+  first: number;
+  second: number;
+}
+
+// These commented solutions can also work
+// type NewType = { first: number; second: number };
+
+// export const addTwoNumbers = (params: { first: number; second: number }) => {
+//   return params.first + params.second;
+// };
+
+export const addTwoNumbers = (params: addNumberProps) => {
   return params.first + params.second;
 };
 
@@ -9,13 +21,13 @@ it("Should add the two numbers together", () => {
     addTwoNumbers({
       first: 2,
       second: 4,
-    }),
+    })
   ).toEqual(6);
 
   expect(
     addTwoNumbers({
       first: 10,
       second: 20,
-    }),
+    })
   ).toEqual(30);
 });


### PR DESCRIPTION
# Add Types to Object Params

This PR holds a change that adds a type to an object parameter in three different ways

Fixes # (execise 02)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Tested locally using `npm run exercise 02`



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
